### PR TITLE
ci: build and push multi-arch container images

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,24 @@
+{
+  "features": {
+    "ghcr.io/devcontainers-extra/features/pre-commit:2.0.18": {
+      "version": "2.0.18",
+      "resolved": "ghcr.io/devcontainers-extra/features/pre-commit@sha256:6e0bb2ce80caca1d94f44dab5d0653d88a1c00984e590adb7c6bce012d0ade6e",
+      "integrity": "sha256:6e0bb2ce80caca1d94f44dab5d0653d88a1c00984e590adb7c6bce012d0ade6e"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1.1.0": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/node:2.0.0": {
+      "version": "2.0.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f",
+      "integrity": "sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f"
+    },
+    "ghcr.io/dhoeric/features/hadolint:1.0.0": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/dhoeric/features/hadolint@sha256:993e7e6f14b7f53aafefb081eb8396ea08f3d48aebb23c91fbaa10651ca0a835",
+      "integrity": "sha256:993e7e6f14b7f53aafefb081eb8396ea08f3d48aebb23c91fbaa10651ca0a835"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,6 @@
     "image": "mcr.microsoft.com/devcontainers/base:debian@sha256:a07f1804d8e665ff64bf6adcd60f4d9b9223dc52ee18a1f1a7a8e1ee1a134d34",
     // Available features: https://containers.dev/features
     "features": {
-        "ghcr.io/devcontainers/features/copilot-cli:1.1.3": {},
         "ghcr.io/devcontainers/features/github-cli:1.1.0": {},
         "ghcr.io/devcontainers/features/node:2.0.0": {
             "version": "lts",
@@ -18,7 +17,7 @@
     },
     "postCreateCommand": {
         "Enable corepack": "corepack enable && corepack install -g yarn",
-        "Install npm tools": "npm install -g @google/gemini-cli markdownlint-cli",
+        "Install npm tools": "npm install -g markdownlint-cli",
         // Install pre-commit hooks in the background since they can take a
         // while, and we want to minimize waiting during `git commit`
         "Initialize pre-commit environment": "nohup sh -c 'pre-commit install -f --install-hooks &' < /dev/null > /dev/null 2>&1"

--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -100,6 +100,10 @@ jobs:
         # https://github.com/actions/checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Set up QEMU
+        # https://github.com/docker/setup-qemu-action
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
       - name: Set up Docker Buildx
         # https://github.com/docker/setup-buildx-action
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -143,7 +147,7 @@ jobs:
           annotations: ${{ steps.meta.outputs.annotations }}
           context: ./${{ matrix.image }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha,scope=container-${{ matrix.image }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+/.antigravitycli/

--- a/start-agy
+++ b/start-agy
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+set -e
+
+# Don't sign commits by the agent
+export GIT_CONFIG_KEY_0=commit.gpgsign
+export GIT_CONFIG_VALUE_0=false
+export GIT_CONFIG_KEY_1=tag.gpgsign
+export GIT_CONFIG_VALUE_1=false
+export GIT_CONFIG_COUNT=2
+
+exec agy --dangerously-skip-permissions


### PR DESCRIPTION
This PR adds support for building and pushing multi-arch container images (linux/amd64 and linux/arm64) by setting up QEMU and updating buildx platforms. It also updates the devcontainer configuration.